### PR TITLE
sorcery_rune available at start...

### DIFF
--- a/techtree/dark_side/factions/dark_magic/units/acolyte/acolyte.xml
+++ b/techtree/dark_side/factions/dark_magic/units/acolyte/acolyte.xml
@@ -252,9 +252,9 @@
 			<build-skill value="build_skill"/>
 			<buildings>
 				<building name="blood_fountain"/>
+				<building name="oblivion_portal"/>
 				<building name="sorcery_runes"/>
 				<building name="hellgate"/>
-				<building name="oblivion_portal"/>
 				<building name="divination_crystal"/>
 				<building name="poisen_morel"/>
 				<building name="dark_castle"/>

--- a/techtree/dark_side/factions/dark_magic/units/dark_elder/dark_elder.xml
+++ b/techtree/dark_side/factions/dark_magic/units/dark_elder/dark_elder.xml
@@ -6,11 +6,11 @@
 		<height value="1"/>
 		<max-hp value="950" regeneration="4"/>
 		<max-ep value="0" regeneration="0"/>
-		<armor value="20"/>	
+		<armor value="20"/>
 		<armor-type value="leather"/>
 		<sight value="14"/>
-		<time value="200"/>	
-		<multi-selection value="true"/>	
+		<time value="200"/>
+		<multi-selection value="true"/>
 		<cellmap value="false"/>
 		<levels>
 			<level name="wise" kills="5"/>
@@ -19,11 +19,11 @@
 		</levels>
 		<fields>
 			<field value="land"/>
-		</fields>	
+		</fields>
 		<properties/>
 		<light enabled="false"/>
 		<unit-requirements>
-			<unit name="divination_crystal"/>
+			<unit name="sorcery_runes"/>
 			<unit name="oblivion_portal"/>
 		</unit-requirements>
 		<upgrade-requirements>
@@ -62,7 +62,7 @@
 			<animation path="models/elder_standing.g3d"/>
 			<sound enabled="false"/>
 		</skill>
-		
+
     <skill>
 			<type value="move"/>
 			<name value="charge_skill"/>
@@ -72,7 +72,7 @@
 			<animation path="models/elder_charging.g3d"/>
 			<sound enabled="false"/>
 		</skill>
-    		
+
 		<skill>
 			<type value="move"/>
 			<name value="move_skill"/>
@@ -85,7 +85,7 @@
 
 		<skill>
 			<type value="attack"/>
-			<name value="attack_skill"/>		
+			<name value="attack_skill"/>
 			<ep-cost value="0"/>
 			<speed value="75"/>
 			<anim-speed value="75"/>
@@ -107,10 +107,10 @@
 			<projectile value="false"/>
 			<splash value="false"/>
 		</skill>
-		
+
     <skill>
 			<type value="attack"/>
-			<name value="attack_air_skill"/>		
+			<name value="attack_air_skill"/>
 			<ep-cost value="0"/>
 			<speed value="75"/>
 			<anim-speed value="75"/>
@@ -142,7 +142,7 @@
 
 		<skill>
 			<type value="die"/>
-			<name value="die_skill"/>	
+			<name value="die_skill"/>
 			<ep-cost value="0"/>
 			<speed value="120"/>
 			<anim-speed value="120"/>
@@ -153,13 +153,13 @@
 				<sound-file path="sounds/die3.wav"/>
 				<sound-file path="sounds/die4.wav"/>
 				<sound-file path="sounds/die5.wav"/>
-			</sound>			
+			</sound>
 			<fade value="true"/>
 		</skill>
 
 		<skill>
 			<type value="build"/>
-			<name value="build_skill"/>		
+			<name value="build_skill"/>
 			<ep-cost value="0"/>
 			<speed value="150"/>
 			<anim-speed value="20"/>
@@ -168,7 +168,7 @@
 		</skill>
 
 	</skills>
-	
+
 	<commands>
 		<command>
 			<type value="stop"/>
@@ -197,7 +197,7 @@
 			<move-skill value="charge_skill"/>
 			<attack-skill value="attack_skill"/>
 		</command>
-		
+
 		<command>
 			<type value="attack"/>
 			<name value="attack_air"/>
@@ -222,7 +222,7 @@
 			<start-sound enabled="false"/>
 			<built-sound enabled="false"/>
 		</command>
-		
+
 		<command>
 			<type value="attack_stopped"/>
 			<name value="hold_position"/>
@@ -231,7 +231,7 @@
 			<upgrade-requirements/>
 			<stop-skill value="stop_skill"/>
 			<attack-skill value="attack_skill"/>
-		</command>			
-		
+		</command>
+
 	</commands>
 </unit>

--- a/techtree/dark_side/factions/dark_magic/units/divination_crystal/divination_crystal.xml
+++ b/techtree/dark_side/factions/dark_magic/units/divination_crystal/divination_crystal.xml
@@ -19,14 +19,17 @@
 		<properties/>
 		<light enabled="false" />
 		<unit-requirements>
+			<unit name="sorcery_runes"/>
 		</unit-requirements>
-		<upgrade-requirements />
+		<upgrade-requirements/>
 		<resource-requirements>
 			<resource name="gold" amount="200" />
 			<resource name="stone" amount="50" />
 			<resource name="wood" amount="150" />
 		</resource-requirements>
-		<resources-stored/>
+		<resources-stored>
+			<resource name="stone" amount="200" />
+		</resources-stored>
 		<image path="images/divination_crystal.bmp"/>
 		<image-cancel path="../dark_elder/images/dark_magic_cancel.bmp"/>
 		<meeting-point value="false"/>

--- a/techtree/dark_side/factions/dark_magic/units/sorcery_runes/sorcery_runes.xml
+++ b/techtree/dark_side/factions/dark_magic/units/sorcery_runes/sorcery_runes.xml
@@ -23,7 +23,6 @@
 		<properties/>
 		<light enabled="false"/>
 		<unit-requirements>
-			<unit name="oblivion_portal"/>
 		</unit-requirements>
 		<upgrade-requirements />
 		<resource-requirements>
@@ -31,7 +30,7 @@
 			<resource name="stone" amount="150"/>
 		</resource-requirements>
 		<resources-stored>
-			<resource name="stone" amount="200" />
+			<resource name="wood" amount="200" />
 		</resources-stored>
 		<image path="images/sorcery_runes.bmp"/>
 		<image-cancel path="../dark_elder/images/dark_magic_cancel.bmp"/>


### PR DESCRIPTION
*acolyte morph to dark elder now requires sorcery run instead of
divination crystal

*move stone storage from sorcery rune to div crystal

*sorcery rune stores 200 wood

*reorder acolyte build menu